### PR TITLE
Changing Crypto Library used due to incorrect signature being created

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "coveralls": "^2.10.0"
   },
   "dependencies": {
-    "randomstring": "^1.1.4",
-    "crypto-js": "^3.1.6"
+    "crypto": "0.0.3",
+    "crypto-js": "^3.1.6",
+    "randomstring": "^1.1.4"
   }
 }

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -16,7 +16,7 @@ const Utils = require('./utils');
  * let oauth = new OAuth({
  * 	consumer: {
  * 		public: '<consumer key>',
- * 		private: '<consumer secret>',
+ * 		secret: '<consumer secret>',
  * 	}
  * });
  * let request_data = {

--- a/src/signer/hmac-sha1.js
+++ b/src/signer/hmac-sha1.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const CryptoJS = require('crypto-js');
+const crypto = require('crypto');
 
 module.exports = (base_string, key) => {
-	return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
+	return crypto.createHmac('sha1', key).update(base_string).digest('base64')
 };

--- a/src/signer/hmac-sha256.js
+++ b/src/signer/hmac-sha256.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const CryptoJS = require('crypto-js');
+const crypto = require('crypto');
 
 module.exports = (base_string, key) => {
-	return CryptoJS.HmacSHA256(base_string, key).toString(CryptoJS.enc.Base64);
+	return crypto.createHmac('sha256', key).update(base_string).digest('base64')
 };


### PR DESCRIPTION
-Updated from crypto-js to crypto
-Updated JSDoc in the oauth file to display the correct properties

Tested this library out in node while it was still using the crypto-js library and the signatures being created were off. I replaced it with the crypto library and it seemed to fix the problem.  It could of been due to an incorrect option set on the crypto-js library? Im not sure, i didnt have the time to get to deep in the debugging. I was also unable to update all the vendor tests as i am unsure what i should change and what not to change especially since this is also used for the browser. I wouldn't mind updating all of that but would need some guidance.
